### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XTPaster
 iOS Paster Function
 
-###HOW TO USE IT ? (使用方式原文链接) http://www.jianshu.com/p/d873d348bbfb
+### HOW TO USE IT ? (使用方式原文链接) http://www.jianshu.com/p/d873d348bbfb
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
